### PR TITLE
feat(zero-api): email confirmation endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ LOG_LEVELS=log,error,warn,debug,verbose
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/zero"
 JWT_SECRET="secret"
 JWT_TTL="1h"
+EMAIL_CONFIRMATION_TTL=86400

--- a/apps/zero-api/src/auth/auth.service.spec.ts
+++ b/apps/zero-api/src/auth/auth.service.spec.ts
@@ -2,10 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UsersService } from '../users/users.service';
-import {UserRole} from '@prisma/client'
+import { User, UserRole } from '@prisma/client';
 import { AuthModule } from './auth.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
+import { createAndActivateUser } from '../../test/helpers';
 
 describe('AuthService', () => {
   let module: TestingModule;
@@ -35,13 +36,13 @@ describe('AuthService', () => {
 
   it('should validate a user', async function() {
     const password = 'test password';
-    const user = await usersService.create({
+    const user = await createAndActivateUser(usersService, prismaService, {
       firstName: 'John',
       lastName: 'Smith',
       email: 'john.smith@foo.bar',
       password,
       roles: [UserRole.seller]
-    });
+    } as User);
 
     expect(await authService.validateUser(user.email, password)).toBeDefined();
     expect(await authService.validateUser('incorrect@email.com', password)).toBeNull();

--- a/apps/zero-api/src/auth/auth.service.ts
+++ b/apps/zero-api/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import * as bcrypt from 'bcryptjs';
 import { UserEntity } from '../users/entities/user.entity';
@@ -16,7 +16,13 @@ export class AuthService {
   async validateUser(email: string, password: string): Promise<UserEntity> {
     const user = await this.usersService.findByEmail(email);
 
-    if (user && await bcrypt.compare(password, user.password)) {
+    if (!user) return null;
+
+    if (!user.emailConfirmed) {
+      throw new HttpException('email not confirmed', HttpStatus.FORBIDDEN);
+    }
+
+    if (await bcrypt.compare(password, user.password)) {
       return new UserEntity(user);
     }
 

--- a/apps/zero-api/src/drafts/drafts.service.spec.ts
+++ b/apps/zero-api/src/drafts/drafts.service.spec.ts
@@ -27,6 +27,7 @@ describe('DraftsService', () => {
   });
 
   beforeEach(async () => {
+    await prisma.emailConfirmation.deleteMany();
     await prisma.draft.deleteMany();
     await prisma.user.deleteMany();
 

--- a/apps/zero-api/src/prisma/prisma.service.ts
+++ b/apps/zero-api/src/prisma/prisma.service.ts
@@ -16,6 +16,7 @@ export class PrismaService extends PrismaClient
   }
 
   async clearDatabase() {
+    await this.emailConfirmation.deleteMany();
     await this.draft.deleteMany();
     await this.passwordReset.deleteMany();
     await this.user.deleteMany();

--- a/apps/zero-api/src/users/dto/create-email-confirmation.dto.ts
+++ b/apps/zero-api/src/users/dto/create-email-confirmation.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class CreateEmailConfirmationDto {
+  @ApiProperty({ example: 'testuser1@foo.bar' })
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ example: 'test' })
+  @IsNotEmpty()
+  password: string;
+}

--- a/apps/zero-api/src/users/dto/update-email-confirmation.dto.ts
+++ b/apps/zero-api/src/users/dto/update-email-confirmation.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+export class UpdateEmailConfirmationDto {
+  @ApiProperty({ example: '22c026e5-2f67-4ccd-9299-c79b91cb9438' })
+  @IsNotEmpty()
+  token: string;
+}

--- a/apps/zero-api/src/users/entities/user.entity.ts
+++ b/apps/zero-api/src/users/entities/user.entity.ts
@@ -22,6 +22,9 @@ export class UserEntity implements User {
   @Exclude()
   password: string;
 
+  @ApiProperty({ example: false })
+  emailConfirmed: boolean;
+
   @Exclude()
   createdAt: Date;
 

--- a/apps/zero-api/src/users/users-drafts.controller.spec.ts
+++ b/apps/zero-api/src/users/users-drafts.controller.spec.ts
@@ -6,11 +6,12 @@ import { UsersDraftsController } from './users-drafts.controller';
 import { DraftsService } from '../drafts/drafts.service';
 import { UsersService } from './users.service';
 import { UserEntity } from './entities/user.entity';
-import { UserRole, DraftType } from '@prisma/client';
+import { User, UserRole, DraftType } from '@prisma/client';
 import * as request from 'supertest';
 import { DraftDto } from '../drafts/dto/draft.dto';
 import { CreateDraftDto } from '../drafts/dto/create-draft.dto';
 import { UpdateDraftDto } from '../drafts/dto/update-draft.dto';
+import { createAndActivateUser, getAuthBearerHeader, logInUser } from '../../test/helpers';
 
 describe('UsersDraftsController', function() {
   let app: INestApplication;
@@ -45,23 +46,23 @@ describe('UsersDraftsController', function() {
     await prisma.clearDatabase();
 
 
-    user1 = await usersService.create({
+    user1 = await createAndActivateUser(usersService, prisma, {
       firstName: 'test first name 1',
       lastName: 'test last name 1',
       email: 'test-email1@foo.bar',
       roles: [UserRole.seller],
       password: password1
-    });
+    } as User);
 
     accessToken1 = await logInUser(app, user1.email, password1);
 
-    user2 = await usersService.create({
+    user2 = await createAndActivateUser(usersService, prisma,{
       firstName: 'test first name 2',
       lastName: 'test last name 2',
       email: 'test-email2@foo.bar',
       roles: [UserRole.seller],
       password: password2
-    });
+    } as User);
   });
 
   afterAll(async () => {
@@ -260,14 +261,3 @@ describe('UsersDraftsController', function() {
     });
   });
 });
-
-async function logInUser(app: INestApplication, username: string, password: string): Promise<string> {
-  return (await request(app.getHttpServer())
-    .post('/auth/login')
-    .send({ username, password })
-    .expect(HttpStatus.OK)).body.accessToken;
-}
-
-function getAuthBearerHeader(token: string): { Authorization: string } {
-  return { Authorization: `Bearer ${token}` };
-}

--- a/apps/zero-api/src/users/users.controller.spec.ts
+++ b/apps/zero-api/src/users/users.controller.spec.ts
@@ -47,11 +47,13 @@ describe('UsersController', () => {
   });
 
   beforeEach(async () => {
+    await prisma.emailConfirmation.deleteMany();
     await prisma.user.deleteMany();
     expect((await prisma.user.findMany()).length).toEqual(0);
   });
 
   afterEach(async () => {
+    await prisma.emailConfirmation.deleteMany();
     await prisma.user.deleteMany();
     expect((await prisma.user.findMany()).length).toEqual(0);
   });

--- a/apps/zero-api/src/users/users.controller.ts
+++ b/apps/zero-api/src/users/users.controller.ts
@@ -17,7 +17,14 @@ import {
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import { ApiBearerAuth, ApiCreatedResponse, ApiForbiddenResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags
+} from '@nestjs/swagger';
 import { UserEntity } from './entities/user.entity';
 import { NoDataInterceptor } from '../interceptors/NoDataInterceptor';
 import { PrismaClientExceptionFilter } from '../exception-filters/PrismaClientExceptionFilter';
@@ -29,6 +36,7 @@ import { User } from './decorators/user.decorator';
 import { PasswordChangeDto } from './dto/password-change.dto';
 import { PasswordResetInitDto } from './dto/password-reset-init.dto';
 import { PasswordResetDto } from './dto/password-reset.dto';
+import { UpdateEmailConfirmationDto } from './dto/update-email-confirmation.dto';
 
 @Controller('users')
 @UsePipes(ValidationPipe)
@@ -132,6 +140,17 @@ export class UsersController {
 
     await this.usersService.update(res.userId, {password: body.newPassword});
     await this.usersService.passwordResetInvalidate(body.token);
+
+    return { status: 'OK' };
+  }
+
+  @Put('email-confirmation')
+  @Public()
+  @ApiTags('users')
+  @ApiOkResponse()
+  @ApiNotFoundResponse({ description: 'Invalid token provided' })
+  async confirmEmail(@Body() confirmEmailDto: UpdateEmailConfirmationDto) {
+    await this.usersService.confirmEmail(confirmEmailDto.token);
 
     return { status: 'OK' };
   }

--- a/apps/zero-api/src/users/users.service.spec.ts
+++ b/apps/zero-api/src/users/users.service.spec.ts
@@ -45,6 +45,7 @@ describe('UsersService', () => {
   });
 
   beforeEach(async () => {
+    await prisma.emailConfirmation.deleteMany();
     await prisma.user.deleteMany();
   });
 
@@ -62,6 +63,7 @@ describe('UsersService', () => {
       const newUserFetched = await service.findOne(newUser.id);
 
       expect(newUserFetched.email).toEqual(testData1.email);
+      expect(newUserFetched.emailConfirmed).toEqual(false);
     });
 
     it('should create record with hashed password', async function() {

--- a/apps/zero-api/src/users/users.service.ts
+++ b/apps/zero-api/src/users/users.service.ts
@@ -117,4 +117,8 @@ export class UsersService {
 
     return tokenRecord;
   }
+
+  async confirmEmail(token: string) {
+    await this.prisma.emailConfirmation.findUnique({where: {id: token}});
+  }
 }

--- a/apps/zero-api/src/users/users.service.ts
+++ b/apps/zero-api/src/users/users.service.ts
@@ -25,7 +25,10 @@ export class UsersService {
         firstName,
         lastName,
         roles,
-        password: await this.hashPassword(password)
+        password: await this.hashPassword(password),
+        emailConfirmation: {
+          create: [{ expiresAt: new Date(new Date().getTime() + (parseInt(process.env.EMAIL_CONFIRMATION_TTL) || 86400) * 1000) }]
+        }
       }
     });
 

--- a/apps/zero-api/swagger.json
+++ b/apps/zero-api/swagger.json
@@ -77,6 +77,10 @@
             "items": {
               "$ref": "#/components/schemas/UserRole"
             }
+          },
+          "emailConfirmed": {
+            "type": "boolean",
+            "example": false
           }
         },
         "required": [
@@ -84,7 +88,8 @@
           "email",
           "firstName",
           "lastName",
-          "roles"
+          "roles",
+          "emailConfirmed"
         ]
       },
       "CreateUserDto": {
@@ -188,6 +193,18 @@
         "required": [
           "token",
           "newPassword"
+        ]
+      },
+      "UpdateEmailConfirmationDto": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "example": "22c026e5-2f67-4ccd-9299-c79b91cb9438"
+          }
+        },
+        "required": [
+          "token"
         ]
       },
       "DraftType": {
@@ -544,6 +561,33 @@
         "responses": {
           "200": {
             "description": ""
+          }
+        },
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/users/email-confirmation": {
+      "put": {
+        "operationId": "UsersController_confirmEmail",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEmailConfirmationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "404": {
+            "description": "Invalid token provided"
           }
         },
         "tags": [

--- a/apps/zero-api/swagger.json
+++ b/apps/zero-api/swagger.json
@@ -195,6 +195,23 @@
           "newPassword"
         ]
       },
+      "CreateEmailConfirmationDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "testuser1@foo.bar"
+          },
+          "password": {
+            "type": "string",
+            "example": "test"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ]
+      },
       "UpdateEmailConfirmationDto": {
         "type": "object",
         "properties": {
@@ -569,6 +586,31 @@
       }
     },
     "/api/users/email-confirmation": {
+      "post": {
+        "operationId": "UsersController_createEmailConfirmation",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEmailConfirmationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "403": {
+            "description": "unregistered email or incorrect password"
+          }
+        },
+        "tags": [
+          "users"
+        ]
+      },
       "put": {
         "operationId": "UsersController_confirmEmail",
         "parameters": [],

--- a/apps/zero-api/test/helpers.ts
+++ b/apps/zero-api/test/helpers.ts
@@ -1,0 +1,23 @@
+import { UsersService } from '../src/users/users.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { User } from '@prisma/client';
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+
+export async function logInUser(app: INestApplication, username: string, password: string): Promise<string> {
+  return (await request(app.getHttpServer())
+    .post('/auth/login')
+    .send({ username, password })
+    .expect(HttpStatus.OK)).body.accessToken;
+}
+
+export function getAuthBearerHeader(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function createAndActivateUser(usersService: UsersService, prisma: PrismaService, data: User): Promise<User> {
+  const newUser = await usersService.create(data);
+  await usersService.confirmEmail((await prisma.emailConfirmation.findFirst({ where: { userId: newUser.id } })).id);
+
+  return newUser;
+}

--- a/prisma/migrations/20210719152759_initial/migration.sql
+++ b/prisma/migrations/20210719152759_initial/migration.sql
@@ -12,6 +12,7 @@ CREATE TABLE "User" (
     "lastName" TEXT NOT NULL,
     "roles" "UserRole"[],
     "password" TEXT NOT NULL,
+    "emailConfirmed" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
@@ -42,6 +43,19 @@ CREATE TABLE "PasswordReset" (
     PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "EmailConfirmation" (
+    "id" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "valid" BOOLEAN NOT NULL DEFAULT true,
+    "confirmedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "User.email_unique" ON "User"("email");
 
@@ -50,3 +64,6 @@ ALTER TABLE "Draft" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE
 
 -- AddForeignKey
 ALTER TABLE "PasswordReset" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmailConfirmation" ADD FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,16 +11,18 @@ generator client {
 }
 
 model User {
-  id             Int             @id @default(autoincrement())
-  email          String?         @unique
-  firstName      String
-  lastName       String
-  roles          UserRole[]
-  drafts         Draft[]
-  password       String
-  passwordResets PasswordReset[]
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  id                Int                 @id @default(autoincrement())
+  email             String?             @unique
+  firstName         String
+  lastName          String
+  roles             UserRole[]
+  drafts            Draft[]
+  password          String
+  emailConfirmed    Boolean             @default(false)
+  emailConfirmation EmailConfirmation[]
+  passwordResets    PasswordReset[]
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
 }
 
 model Draft {
@@ -42,6 +44,18 @@ model PasswordReset {
   usedAt    DateTime?
   User      User?     @relation(fields: [userId], references: [id])
   userId    Int
+}
+
+model EmailConfirmation {
+  id          String   @id @default(uuid())
+  userId      Int
+  expiresAt   DateTime
+  valid       Boolean  @default(true)
+  confirmedAt DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
 }
 
 enum UserRole {


### PR DESCRIPTION
- email confirmation is created for every new user
- email confirmation can be requested again for an existing user, previous email confirmation requests are invalidated