### PR TITLE
chore(zero-api): env variables validations and defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 LOG_LEVELS=log,error,warn,debug,verbose
+PORT=3333
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/zero"
 SMTP_URL=smtp://localhost:1025
 JWT_SECRET="secret"
-JWT_TTL="1h"
+JWT_TTL="24h"
 EMAIL_CONFIRMATION_TTL=86400
 FILES_STORAGE=./uploaded-files
 UPLOADED_FILES_COUNT_LIMIT=5

--- a/apps/zero-api/src/app/app.module.ts
+++ b/apps/zero-api/src/app/app.module.ts
@@ -12,12 +12,48 @@ import { DraftsModule } from '../drafts/drafts.module';
 import { FilesModule } from '../files/files.module';
 import { HttpLoggerMiddleware } from '../middlewares/http-logger.middleware';
 import { EmailModule } from '../email/email.module';
+import * as Joi from 'joi';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       envFilePath: ['.env'],
-      isGlobal: true
+      isGlobal: true,
+      validationOptions: {
+        allowUnknown: true,
+        abortEarly: false
+      },
+      validationSchema: Joi.object({
+        NODE_ENV: Joi.string()
+          .valid('development', 'production', 'test', 'provision')
+          .default('development'),
+
+        PORT: Joi.number().default(3333),
+
+        DATABASE_URL: Joi.string()
+          .uri({ allowRelative: false, scheme: 'postgres' })
+          .default('postgresql://postgres:postgres@localhost:5432/zero'),
+
+        SMTP_URL: Joi.string()
+          .uri({ allowRelative: false, scheme: 'smtp' })
+          .default('smtp://localhost:1025'),
+
+        UI_BASE_URL: Joi.string()
+          .uri({
+            allowRelative: false,
+            scheme: ['http', 'https']
+          })
+          .default('http://localhost:3000'),
+
+        LOG_LEVELS: Joi.string().default('log,error,warn,debug,verbose'),
+        JWT_SECRET: Joi.string().required(),
+        JWT_TTL: Joi.string().default('24h'),
+        EMAIL_CONFIRMATION_TTL: Joi.number().min(0).default(86400),
+        FILES_STORAGE: Joi.string().default('./uploaded-files'),
+        UPLOADED_FILE_SIZE_LIMIT: Joi.number().min(1000000),
+        CORS_ORIGIN: Joi.string().default('*'),
+        CORS_MAX_AGE: Joi.number().default(60)
+      })
     }),
     PrismaModule,
     UsersModule,

--- a/apps/zero-api/src/auth/auth.module.ts
+++ b/apps/zero-api/src/auth/auth.module.ts
@@ -12,7 +12,7 @@ import { JwtStrategy } from './strategies';
     PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: process.env.JWT_TTL || '24h' },
+      signOptions: { expiresIn: process.env.JWT_TTL },
     }),
   ],
   providers: [AuthService, LocalStrategy, JwtStrategy],

--- a/apps/zero-api/src/auth/auth.module.ts
+++ b/apps/zero-api/src/auth/auth.module.ts
@@ -5,15 +5,22 @@ import { PassportModule } from '@nestjs/passport';
 import { LocalStrategy } from './strategies';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './strategies';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: process.env.JWT_TTL },
-    }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        return {
+          secret: config.get<string>('JWT_SECRET'),
+          signOptions: { expiresIn: config.get<string | number>('JWT_TTL') }
+        };
+      }
+    })
   ],
   providers: [AuthService, LocalStrategy, JwtStrategy],
   exports: [AuthService, JwtModule]

--- a/apps/zero-api/src/files/files.controller.ts
+++ b/apps/zero-api/src/files/files.controller.ts
@@ -36,8 +36,8 @@ const filesInterceptor = FileInterceptor('file', {
   //  This is a temporary storage for files to be processed
   storage: multer.diskStorage({}),
   limits: {
-    files: parseInt(process.env.UPLOADED_FILES_COUNT_LIMIT) || 5,
-    fileSize: parseInt(process.env.UPLOADED_FILE_SIZE_LIMIT) || 1000000
+    files: parseInt(process.env.UPLOADED_FILES_COUNT_LIMIT),
+    fileSize: parseInt(process.env.UPLOADED_FILE_SIZE_LIMIT)
   } // see https://github.com/expressjs/multer#multeropts for options
 });
 

--- a/apps/zero-api/src/files/files.service.ts
+++ b/apps/zero-api/src/files/files.service.ts
@@ -17,7 +17,7 @@ import { FileMetadataDto } from './dto/file-metadata.dto';
 export class FilesService {
   private readonly logger = new Logger(FilesService.name, { timestamp: true });
 
-  private readonly filesStorage = resolve(process.env.FILES_STORAGE || tmpdir());
+  private readonly filesStorage = resolve(process.env.FILES_STORAGE);
 
   constructor(private prisma: PrismaService) {
     this.logger.debug('instantiating');

--- a/apps/zero-api/src/main.ts
+++ b/apps/zero-api/src/main.ts
@@ -21,8 +21,8 @@ async function bootstrap() {
   });
 
   app.enableCors({
-    origin: process.env.CORS_ORIGIN || '*',
-    maxAge: parseInt(process.env.CORS_MAX_AGE) || 60
+    origin: process.env.CORS_ORIGIN,
+    maxAge: parseInt(process.env.CORS_MAX_AGE)
   });
 
   logger.log(`LOG_LEVELS=${getLogLevelsFromEnv().join()}`);
@@ -38,7 +38,7 @@ async function bootstrap() {
     },
   });
 
-  const port = process.env.PORT || 3333;
+  const port = process.env.PORT;
   await app.listen(port, () => {
     logger.log('Listening at http://localhost:' + port + '/' + globalPrefix);
   });
@@ -54,7 +54,7 @@ bootstrap()
 
 function getLogLevelsFromEnv(): LogLevel[] {
   const allowedLogLevels: LogLevel[] = ['log', 'error', 'warn', 'debug', 'verbose'];
-  const envLogLevels = (process.env.LOG_LEVELS || 'error,warn,debug,verbose').split(',') as LogLevel[];
+  const envLogLevels = (process.env.LOG_LEVELS).split(',') as LogLevel[];
 
   return intersection(allowedLogLevels, envLogLevels) as LogLevel[]
 }

--- a/apps/zero-api/src/swagger/SwaggerDocumentConfig.ts
+++ b/apps/zero-api/src/swagger/SwaggerDocumentConfig.ts
@@ -5,6 +5,6 @@ export function getSwaggerDocumentationConfig() {
     .setTitle('Energy Web Zero API')
     .setVersion('0.3')
     .addBearerAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }, 'access-token')
-    .addServer(`http://localhost:${process.env.PORT || 3333}`)
+    .addServer(`http://localhost:${process.env.PORT}`)
     .build();
 }

--- a/apps/zero-api/src/users/users.controller.ts
+++ b/apps/zero-api/src/users/users.controller.ts
@@ -157,7 +157,7 @@ export class UsersController {
 
     if (!(await this.usersService.checkPassword(user.id, createEmailConfirmation.password))) throw new ForbiddenException();
 
-    await this.usersService.createEmailConfirmation(user.id, parseInt(process.env.EMAIL_CONFIRMATION_TTL) || 86400);
+    await this.usersService.createEmailConfirmation(user.id, parseInt(process.env.EMAIL_CONFIRMATION_TTL));
 
     return { status: 'OK' };
   }

--- a/apps/zero-api/src/users/users.service.spec.ts
+++ b/apps/zero-api/src/users/users.service.spec.ts
@@ -4,12 +4,11 @@ import * as _ from 'lodash';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserRole, User, EmailConfirmation } from '@prisma/client';
-import { PrismaModule } from '../prisma/prisma.module';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotFoundException } from '@nestjs/common';
 import { UserDto } from './dto/user.dto';
-import { EmailModule } from '../email/email.module';
 import * as mailhog from 'mailhog';
+import { AppModule } from '../app/app.module';
 
 describe('UsersService', () => {
   let module: TestingModule;
@@ -34,8 +33,8 @@ describe('UsersService', () => {
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
-      imports: [PrismaModule, EmailModule],
-      providers: [UsersService]
+      imports: [AppModule],
+      providers: []
     }).compile();
 
     service = module.get<UsersService>(UsersService);

--- a/apps/zero-api/src/users/users.service.ts
+++ b/apps/zero-api/src/users/users.service.ts
@@ -33,7 +33,7 @@ export class UsersService {
     });
 
 
-    const emailConfirmationToken = await this.createEmailConfirmation(data.id, parseInt(process.env.EMAIL_CONFIRMATION_TTL) || 86400);
+    const emailConfirmationToken = await this.createEmailConfirmation(data.id, parseInt(process.env.EMAIL_CONFIRMATION_TTL));
 
     this.logger.debug(`sending confirmation email to ${data.email}`);
     const url = `${process.env.UI_BASE_URL}/auth/confirm-email#token=${encodeURIComponent(emailConfirmationToken)}`;

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-icu": "2.0.3",
     "immer": "^9.0.5",
+    "joi": "^17.4.2",
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",
     "mkdirp": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,6 +1983,18 @@
   resolved "https://registry.yarnpkg.com/@exodus/schemasafe/-/schemasafe-1.0.0-rc.3.tgz#dda2fbf3dafa5ad8c63dadff7e01d3fdf4736025"
   integrity sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg==
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@hookform/error-message@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.0.tgz#9b1b037fd816ea9b1531c06aa7fab5f5154aa740"
@@ -2451,7 +2463,7 @@
   resolved "https://registry.yarnpkg.com/@nestjs/passport/-/passport-8.0.1.tgz#f1ed39a19489f794d1fe3fef592b4523bc48da68"
   integrity sha512-vn/ZJLXQKvSf9D0BvEoNFJLfzl9AVqfGtDyQMfWDLbaNpoEB2FyeaHGxdiX6H71oLSrQV78c/yuhfantzwdjdg==
 
-"@nestjs/platform-express@^8.0.5":
+"@nestjs/platform-express@8.0.5":
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/@nestjs/platform-express/-/platform-express-8.0.5.tgz#b8443886ec4ac0f5c75e580004c8b32a834c9dca"
   integrity sha512-ystcQWv1Hm/V2IoiDrAYzOxZ+fi0HWUM+A4boI+8Vjl8aBqvMC1PwI1+QxhXnVsnR0nT8OJuJ2z77a9WvfT9uA==
@@ -3084,6 +3096,23 @@
   dependencies:
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
+
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -12542,6 +12571,17 @@ jest@26.2.2:
     import-local "^3.0.2"
     jest-cli "^26.2.2"
 
+joi@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
+  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -18749,7 +18789,7 @@ superagent@^6.1.0:
     readable-stream "^3.6.0"
     semver "^7.3.2"
 
-supertest@^6.1.4:
+supertest@6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.4.tgz#ea8953343e0ca316e80e975b39340934f754eb06"
   integrity sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==


### PR DESCRIPTION
This change results in only JWT_SECRET being set explicitly before executing the backend application. Additionally, validations have been added for env variables values. When validations are not met, the application will not start, but throw an exception.