### PR TITLE
feat: graceful webserver shutdown

### DIFF
--- a/apps/zero-api/src/app/app.module.ts
+++ b/apps/zero-api/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { FilesModule } from '../files/files.module';
 import { HttpLoggerMiddleware } from '../middlewares/http-logger.middleware';
 import { EmailModule } from '../email/email.module';
 import * as Joi from 'joi';
+import { ConnectionCloseMiddleware } from '../middlewares/connection-close.middleware';
 
 @Module({
   imports: [
@@ -72,6 +73,10 @@ export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(HttpLoggerMiddleware)
+      .forRoutes('*');
+
+    consumer
+      .apply(ConnectionCloseMiddleware)
       .forRoutes('*');
   }
 }

--- a/apps/zero-api/src/main.ts
+++ b/apps/zero-api/src/main.ts
@@ -3,7 +3,7 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger, LogLevel } from '@nestjs/common';
+import { INestApplication, Logger, LogLevel } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
 
@@ -17,8 +17,10 @@ const webserverLogger = new Logger('webserver', { timestamp: true });
 
 logger.log('starting');
 
+let app: INestApplication;
+
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
+  app = await NestFactory.create(AppModule, {
     logger: getLogLevelsFromEnv()
   });
 
@@ -66,7 +68,17 @@ bootstrap()
   .catch(err => {
     logger.error(err);
     console.log(err);
-    process.exit(1);
+
+    if (app) {
+      logger.debug('calling app.close()');
+      app.close().then(() => {
+        logger.debug('exiting process with code 1 after app.close()');
+        process.exit(1);
+      });
+    } else {
+      logger.debug('app is undefined, exiting process with code 1');
+      process.exit(1);
+    }
   });
 
 function getLogLevelsFromEnv(): LogLevel[] {

--- a/apps/zero-api/src/middlewares/connection-close.middleware.ts
+++ b/apps/zero-api/src/middlewares/connection-close.middleware.ts
@@ -1,0 +1,22 @@
+import { Logger, NestMiddleware } from '@nestjs/common';
+import { Request, Response } from 'express';
+
+export class ConnectionCloseMiddleware implements NestMiddleware {
+  private shutdownMode = false;
+  private readonly logger = new Logger(ConnectionCloseMiddleware.name, { timestamp: true });
+
+  use(req: Request, res: Response, next: () => void): void {
+    if (this.shutdownMode) {
+      this.logger.debug('shutdown mode, setting "Connection: close" response header');
+      res.setHeader('Connection', 'close');
+    }
+    next();
+  }
+
+  async onModuleDestroy() {
+    this.shutdownMode = true;
+    this.logger.log('entering shutdown mode, ' +
+      'all active connections are going to be closed ' +
+      'after serving responses to ongoing requests');
+  }
+}


### PR DESCRIPTION
- when in "shutdown" state, the webserver is closed (not accepting new connections)
- existing connections are closed after serving a response to requests being processed when termination signal received
- implemented a workaround for Prisma ORM causing NestJS lifecycle hooks not executed on shutdown