### PR TITLE
feat: file upload endpoint improvement

### DIFF
--- a/apps/zero-api/prisma/migrations/20210812093049_initial/migration.sql
+++ b/apps/zero-api/prisma/migrations/20210812093049_initial/migration.sql
@@ -26,6 +26,7 @@ CREATE TABLE "User" (
 CREATE TABLE "File" (
     "id" TEXT NOT NULL,
     "filename" TEXT NOT NULL,
+    "fileExtension" TEXT NOT NULL,
     "mimetype" TEXT NOT NULL,
     "ownerId" INTEGER NOT NULL,
     "fileType" "FileType" NOT NULL,

--- a/apps/zero-api/prisma/schema.prisma
+++ b/apps/zero-api/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
 model File {
   id                    String    @id @default(uuid())
   filename              String
+  fileExtension         String
   mimetype              String
   owner                 User      @relation(fields: [ownerId], references: [id])
   ownerId               Int

--- a/apps/zero-api/src/files/dto/file-metadata.dto.ts
+++ b/apps/zero-api/src/files/dto/file-metadata.dto.ts
@@ -9,6 +9,9 @@ export class FileMetadataDto implements File {
   @ApiProperty({ example: 'agreement.pdf' })
   filename: string;
 
+  @ApiProperty({ example: 'pdf' })
+  fileExtension: string;
+
   @ApiProperty({ example: 'application/pdf' })
   mimetype: string;
 

--- a/apps/zero-api/src/files/files.controller.ts
+++ b/apps/zero-api/src/files/files.controller.ts
@@ -83,6 +83,17 @@ export class FilesController {
     }
 
     const fileExtensionDetected = mimeTypes.extension(file.mimetype);
+
+    if (!fileExtensionDetected) {
+      this.logger.warn(`unrecognized mimetype: ${file.mimetype}`);
+      throw new BadRequestException(`unrecognized mimetype: ${file.mimetype}`);
+    }
+
+    if ([...this.supportedDocumentsFormats, ...this.supportedImagesFormats].indexOf(fileExtensionDetected) < 0) {
+      this.logger.warn(`unsupported file extension detected (${fileExtensionDetected}) for ${file.mimetype} mimetype`);
+      throw new BadRequestException(`unsupported mimetype (${file.mimetype})`);
+    }
+
     this.logger.debug((`detected ${fileExtensionDetected} file extension for ${file.mimetype} mimetype`));
 
     const newFileRecord = await this.filesService.addFile(file, fileExtensionDetected, user.id, body.fileType, meta);

--- a/apps/zero-api/src/files/files.service.spec.ts
+++ b/apps/zero-api/src/files/files.service.spec.ts
@@ -66,7 +66,7 @@ describe('FilesService', () => {
     });
 
     it('should create database record', async function() {
-      const res = await service.addFile(uploadedFile, user.id, FileType.facility,  {meta: "data"});
+      const res = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
 
       const databaseRecord = await prismaService.file.findUnique({ where: { id: res.id } });
       expect(databaseRecord).toBeDefined();
@@ -77,7 +77,7 @@ describe('FilesService', () => {
     });
 
     it('should store a file in the destination folder', async function() {
-      const res = await service.addFile(uploadedFile, user.id, FileType.facility,  {meta: "data"});
+      const res = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
 
       expect(await fileExists(resolve(destinationFolder, res.id))).toEqual(true);
     });
@@ -88,7 +88,7 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
       const uploadedFile = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      file = await service.addFile(uploadedFile, user.id, FileType.facility,  {meta: "data"});
+      file = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
     });
 
     it('should return existing file metadata record', async function() {
@@ -107,7 +107,7 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
       const uploadedFile = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      file = await service.addFile(uploadedFile, user.id, FileType.facility,  {meta: "data"});
+      file = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
     });
 
     it('should return a file stream', async function() {
@@ -133,11 +133,11 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
 
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), anotherUser.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', anotherUser.id, FileType.facility,  {meta: "data"})
 
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user.id, FileType.facility,  {meta: "data"})
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user.id, FileType.facility,  {meta: "data"})
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
     });
 
     afterEach(async function() {

--- a/apps/zero-api/src/files/files.service.ts
+++ b/apps/zero-api/src/files/files.service.ts
@@ -24,13 +24,14 @@ export class FilesService {
     mkdirp.sync(this.filesStorage);
   }
 
-  async addFile(file: Express.Multer.File, owner: number, fileType: FileType, meta: Prisma.JsonValue): Promise<FileMetadataDto> {
+  async addFile(file: Express.Multer.File, fileExtension: string, owner: number, fileType: FileType, meta: Prisma.JsonValue): Promise<FileMetadataDto> {
     this.logger.debug(`processing file: ${JSON.stringify(pick(file, ['originalname', 'path', 'size']))}`);
 
     try {
       let fileRecord: File = await this.prisma.file.create({
         data: {
           filename: file.originalname,
+          fileExtension,
           ownerId: owner,
           fileType,
           meta,

--- a/apps/zero-api/src/users/users-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-files.controller.spec.ts
@@ -85,13 +85,12 @@ describe('UsersFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user2.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id, FileType.facility, null);
 
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
     });
-
 
     it('should deny access when not authenticated', async function() {
       const { body } = (await request(httpServer)

--- a/apps/zero-api/src/users/users-own-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-own-files.controller.spec.ts
@@ -82,13 +82,12 @@ describe('UsersOwnFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user2.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id, FileType.facility, null);
 
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
     });
-
 
     it('should deny access when not authenticated', async function() {
       const { body } = (await request(httpServer)

--- a/apps/zero-api/swagger.json
+++ b/apps/zero-api/swagger.json
@@ -1214,6 +1214,10 @@
             "type": "string",
             "example": "agreement.pdf"
           },
+          "fileExtension": {
+            "type": "string",
+            "example": "pdf"
+          },
           "mimetype": {
             "type": "string",
             "example": "application/pdf"
@@ -1241,6 +1245,7 @@
         "required": [
           "id",
           "filename",
+          "fileExtension",
           "mimetype",
           "ownerId",
           "fileType",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "joi": "^17.4.2",
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",
+    "mime-types": "^2.1.32",
     "mkdirp": "^1.0.4",
     "nodemailer": "^6.6.3",
     "notistack": "^2.0.1-alpha.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13865,12 +13865,24 @@ mime-db@1.48.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.31"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
   integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
     mime-db "1.48.0"
+
+mime-types@^2.1.32:
+  version "2.1.32"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
+  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+  dependencies:
+    mime-db "1.49.0"
 
 mime@1.6.0, mime@^1.4.1, mime@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
File upload endpoint improvement:
- added mimetype -> file extension mapping
- accepting file type based on detected file extension
- storing file extension in the database to support moving files storage to an external service
- including file extension in file entity served in responses by files endpoints