### PR TITLE
chore: file upload endpoint redesigned

### DIFF
--- a/apps/zero-api/prisma/migrations/20210812153431_initial/migration.sql
+++ b/apps/zero-api/prisma/migrations/20210812153431_initial/migration.sql
@@ -29,7 +29,7 @@ CREATE TABLE "File" (
     "fileExtension" TEXT NOT NULL,
     "mimetype" TEXT NOT NULL,
     "ownerId" INTEGER NOT NULL,
-    "fileType" "FileType" NOT NULL,
+    "fileType" "FileType",
     "meta" JSONB,
     "uploadedAt" TIMESTAMP(3) NOT NULL,
     "processingCompletedAt" TIMESTAMP(3),

--- a/apps/zero-api/prisma/schema.prisma
+++ b/apps/zero-api/prisma/schema.prisma
@@ -33,7 +33,7 @@ model File {
   mimetype              String
   owner                 User      @relation(fields: [ownerId], references: [id])
   ownerId               Int
-  fileType              FileType
+  fileType              FileType?
   meta                  Json?
   uploadedAt            DateTime
   processingCompletedAt DateTime?

--- a/apps/zero-api/src/files/dto/upload-file-response.dto.ts
+++ b/apps/zero-api/src/files/dto/upload-file-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { FileMetadataDto } from './file-metadata.dto';
+
+@Exclude()
+export class UploadFileResponseDto extends PartialType(PickType(FileMetadataDto, ['id'])){
+  @Expose()
+  @ApiProperty({ example: '5ff1cb39-da8b-4f0a-a17d-a5d00ea85a60' })
+  id: string;
+
+  constructor(partial: Partial<UploadFileResponseDto>) {
+    super(partial);
+    Object.assign(this, partial);
+  }
+}

--- a/apps/zero-api/src/files/dto/upload-file.dto.ts
+++ b/apps/zero-api/src/files/dto/upload-file.dto.ts
@@ -5,12 +5,4 @@ import { IsEnum, IsOptional } from 'class-validator';
 export class UploadFileDto {
   @ApiProperty({ type: 'string', format: 'binary' })
   file: unknown;
-
-  @ApiProperty({enum: FileType, enumName: 'FileType'})
-  @IsEnum(FileType)
-  fileType: FileType;
-
-  @ApiPropertyOptional({ example: '{ "field1": "value", "field2" : [1, 2, 3] }' })
-  @IsOptional()
-  meta?: string
 }

--- a/apps/zero-api/src/files/files.controller.spec.ts
+++ b/apps/zero-api/src/files/files.controller.spec.ts
@@ -78,7 +78,6 @@ describe('FilesController', () => {
     it('should require logged in user', async function() {
       await request(httpServer)
         .post('/files')
-        .field('fileType', FileType.facility)
         .attach('file', testFilePath)
         .expect(HttpStatus.UNAUTHORIZED);
     });
@@ -86,7 +85,6 @@ describe('FilesController', () => {
     it('should create a file', async function() {
       const newFileId: string = (await request(httpServer)
         .post('/files')
-        .field('fileType', FileType.facility)
         .field('meta', JSON.stringify({ meta: 'data' }))
         .attach('file', testFilePath)
         .set(getAuthBearerHeader(accessToken))

--- a/apps/zero-api/src/files/files.controller.ts
+++ b/apps/zero-api/src/files/files.controller.ts
@@ -31,7 +31,6 @@ import { UserDto } from '../users/dto/user.dto';
 import { isNil } from '@nestjs/common/utils/shared.utils';
 import { Public } from '../auth/decorators/public.decorator';
 import * as mimeTypes from 'mime-types';
-import {FileType} from '@prisma/client';
 import { UploadFileResponseDto } from './dto/upload-file-response.dto';
 
 const filesInterceptor = FileInterceptor('file', {

--- a/apps/zero-api/src/files/files.service.spec.ts
+++ b/apps/zero-api/src/files/files.service.spec.ts
@@ -66,18 +66,16 @@ describe('FilesService', () => {
     });
 
     it('should create database record', async function() {
-      const res = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
+      const res = await service.addFile(uploadedFile, 'pdf', user.id);
 
       const databaseRecord = await prismaService.file.findUnique({ where: { id: res.id } });
       expect(databaseRecord).toBeDefined();
       expect(databaseRecord.filename).toEqual(uploadedFile.originalname);
-      expect(databaseRecord.fileType).toEqual(FileType.facility);
-      expect(databaseRecord.meta).toEqual({meta: "data"});
       expect(databaseRecord.ownerId).toEqual(user.id);
     });
 
     it('should store a file in the destination folder', async function() {
-      const res = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
+      const res = await service.addFile(uploadedFile, 'pdf', user.id);
 
       expect(await fileExists(resolve(destinationFolder, res.id))).toEqual(true);
     });
@@ -88,7 +86,7 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
       const uploadedFile = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      file = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
+      file = await service.addFile(uploadedFile, 'pdf', user.id);
     });
 
     it('should return existing file metadata record', async function() {
@@ -107,7 +105,7 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
       const uploadedFile = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      file = await service.addFile(uploadedFile, 'pdf', user.id, FileType.facility,  {meta: "data"});
+      file = await service.addFile(uploadedFile, 'pdf', user.id);
     });
 
     it('should return a file stream', async function() {
@@ -133,11 +131,11 @@ describe('FilesService', () => {
 
     beforeEach(async function() {
 
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', anotherUser.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', anotherUser.id)
 
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
-      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id, FileType.facility,  {meta: "data"})
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id)
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id)
+      await service.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user.id)
     });
 
     afterEach(async function() {

--- a/apps/zero-api/src/files/files.service.ts
+++ b/apps/zero-api/src/files/files.service.ts
@@ -8,9 +8,10 @@ import { Multer } from 'multer';
 import { dirname, resolve } from 'path';
 import * as mkdirp from 'mkdirp';
 import { copyFile, rename, stat, unlink } from 'fs/promises';
-import { File, FileType, Prisma } from '@prisma/client';
+import { File } from '@prisma/client';
 import { createReadStream, ReadStream } from 'fs';
 import { FileMetadataDto } from './dto/file-metadata.dto';
+import { UploadFileResponseDto } from './dto/upload-file-response.dto';
 
 @Injectable()
 export class FilesService {
@@ -24,7 +25,7 @@ export class FilesService {
     mkdirp.sync(this.filesStorage);
   }
 
-  async addFile(file: Express.Multer.File, fileExtension: string, owner: number, fileType: FileType, meta: Prisma.JsonValue): Promise<FileMetadataDto> {
+  async addFile(file: Express.Multer.File, fileExtension: string, owner: number): Promise<UploadFileResponseDto> {
     this.logger.debug(`processing file: ${JSON.stringify(pick(file, ['originalname', 'path', 'size']))}`);
 
     try {
@@ -33,8 +34,6 @@ export class FilesService {
           filename: file.originalname,
           fileExtension,
           ownerId: owner,
-          fileType,
-          meta,
           mimetype: file.mimetype,
           uploadedAt: new Date()
         }
@@ -68,7 +67,7 @@ export class FilesService {
         data: { processingCompletedAt: new Date() }
       });
 
-      return new FileMetadataDto(fileRecord);
+      return new UploadFileResponseDto(fileRecord);
     } catch (err) {
       this.logger.error(err);
       throw err;

--- a/apps/zero-api/src/users/users-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-files.controller.spec.ts
@@ -85,11 +85,11 @@ describe('UsersFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id);
 
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
     });
 
     it('should deny access when not authenticated', async function() {

--- a/apps/zero-api/src/users/users-own-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-own-files.controller.spec.ts
@@ -82,11 +82,11 @@ describe('UsersOwnFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user2.id);
 
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
-      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id, FileType.facility, null);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
+      await filesService.addFile(await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder), 'pdf', user1.id);
     });
 
     it('should deny access when not authenticated', async function() {

--- a/apps/zero-api/swagger.json
+++ b/apps/zero-api/swagger.json
@@ -1259,18 +1259,10 @@
           "file": {
             "type": "string",
             "format": "binary"
-          },
-          "fileType": {
-            "$ref": "#/components/schemas/FileType"
-          },
-          "meta": {
-            "type": "string",
-            "example": "{ \"field1\": \"value\", \"field2\" : [1, 2, 3] }"
           }
         },
         "required": [
-          "file",
-          "fileType"
+          "file"
         ]
       }
     }


### PR DESCRIPTION
POST /files endpoint accepts only a single file and responds with newly created file id (uuid). Metadata will be set with another endpoint to be implemented later.