### PR TITLE
feat: products endpoints base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - feat/facilities
+      - feat/products
 
 jobs:
   cancel-previous:

--- a/apps/zero-api/prisma/migrations/20210819103540_initial/migration.sql
+++ b/apps/zero-api/prisma/migrations/20210819103540_initial/migration.sql
@@ -87,6 +87,17 @@ CREATE TABLE "Facility" (
     PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "facilityId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "User.email_unique" ON "User"("email");
 
@@ -104,3 +115,6 @@ ALTER TABLE "EmailConfirmation" ADD FOREIGN KEY ("userId") REFERENCES "User"("id
 
 -- AddForeignKey
 ALTER TABLE "Facility" ADD FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD FOREIGN KEY ("facilityId") REFERENCES "Facility"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/zero-api/prisma/schema.prisma
+++ b/apps/zero-api/prisma/schema.prisma
@@ -76,13 +76,24 @@ model EmailConfirmation {
 }
 
 model Facility {
-  id      Int  @id @default(autoincrement())
+  id      Int       @id @default(autoincrement())
   name    String
-  User    User @relation(fields: [ownerId], references: [id])
+  User    User      @relation(fields: [ownerId], references: [id])
   ownerId Int
+  Product Product[]
 
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Product {
+  id         Int      @id @default(autoincrement())
+  name       String
+  Facility   Facility @relation(fields: [facilityId], references: [id])
+  facilityId Int
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 enum UserRole {

--- a/apps/zero-api/src/app/app.module.ts
+++ b/apps/zero-api/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { EmailModule } from '../email/email.module';
 import * as Joi from 'joi';
 import { ConnectionCloseMiddleware } from '../middlewares/connection-close.middleware';
 import { FacilitiesModule } from '../facilities/facilities.module';
+import { ProductsModule } from '../products/products.module';
 
 @Module({
   imports: [
@@ -63,7 +64,8 @@ import { FacilitiesModule } from '../facilities/facilities.module';
     DraftsModule,
     FilesModule,
     EmailModule,
-    FacilitiesModule
+    FacilitiesModule,
+    ProductsModule
   ],
   controllers: [AppController],
   providers: [

--- a/apps/zero-api/src/products/dto/create-product.dto.ts
+++ b/apps/zero-api/src/products/dto/create-product.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateProductDto {
+  @ApiProperty({ example: 'My product' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: 1 })
+  @IsInt()
+  facilityId: number;
+}

--- a/apps/zero-api/src/products/dto/product.dto.ts
+++ b/apps/zero-api/src/products/dto/product.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Product } from '@prisma/client';
+import { Exclude } from 'class-transformer';
+
+export class ProductDto implements Product {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 1 })
+  facilityId: number;
+
+  @ApiProperty({ example: 'My product' })
+  name: string;
+
+  @Exclude()
+  createdAt: Date;
+
+  @Exclude()
+  updatedAt: Date;
+
+  constructor(partial: Partial<ProductDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/apps/zero-api/src/products/dto/update-product.dto.ts
+++ b/apps/zero-api/src/products/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/apps/zero-api/src/products/products.controller.spec.ts
+++ b/apps/zero-api/src/products/products.controller.spec.ts
@@ -1,0 +1,348 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsController } from './products.controller';
+import { createAndActivateUser, getAuthBearerHeader, logInUser } from '../../test/helpers';
+import { AppModule } from '../app/app.module';
+import { UsersService } from '../users/users.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { User, UserRole } from '@prisma/client';
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { FacilitiesService } from '../facilities/facilities.service';
+import { FacilityDto } from '../facilities/dto/facility.dto';
+
+describe('ProductsController', () => {
+  let controller: ProductsController;
+  let app: INestApplication;
+  let httpServer;
+  let prisma: PrismaService;
+  let usersService: UsersService;
+  let facilitiesService: FacilitiesService;
+  let user1: User, accessToken1: string;
+  let adminUser: User, adminAccessToken: string;
+  let user2: User, accessToken2: string;
+  let facility1: FacilityDto, facility2: FacilityDto;
+
+  beforeAll(async function() {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    httpServer = app.getHttpServer();
+
+    controller = module.get<ProductsController>(ProductsController);
+    usersService = module.get<UsersService>(UsersService);
+    facilitiesService = module.get<FacilitiesService>(FacilitiesService);
+    prisma = module.get<PrismaService>(PrismaService);
+
+    await prisma.clearDatabase();
+
+    user1 = await createAndActivateUser(usersService, prisma, {
+      firstName: 'test first name 1',
+      lastName: 'test last name 1',
+      email: 'test-email1@foo.bar',
+      roles: [UserRole.seller],
+      password: 'password'
+    } as User);
+
+    accessToken1 = await logInUser(app, user1.email, 'password');
+
+
+    user2 = await createAndActivateUser(usersService, prisma, {
+      firstName: 'test first name 2',
+      lastName: 'test last name 2',
+      email: 'test-email2@foo.bar',
+      roles: [UserRole.seller],
+      password: 'password'
+    } as User);
+
+    accessToken2 = await logInUser(app, user2.email, 'password');
+
+    adminUser = await createAndActivateUser(usersService, prisma, {
+      firstName: 'admin first name',
+      lastName: 'admin last name',
+      email: 'admin-email1@foo.bar',
+      roles: [UserRole.admin],
+      password: 'admin password'
+    } as User);
+
+    adminAccessToken = await logInUser(app, adminUser.email, 'admin password');
+
+    facility1 = await facilitiesService.create({ name: 'Facility 1' }, user1.id);
+    facility2 = await facilitiesService.create({ name: 'Facility 2' }, user2.id);
+  });
+
+  afterAll(async function() {
+    await app.close();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /products', function() {
+    it('should require a logged in user', async function() {
+      await request(httpServer)
+        .post('/products')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should create a new product', async function() {
+      await prisma.product.deleteMany();
+
+      await request(httpServer)
+        .post('/products')
+        .send({ name: 'My first awesome product', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED);
+
+      const dbRows = await prisma.product.findMany();
+      expect(dbRows.length).toEqual(1);
+      expect(dbRows[0].name).toEqual('My first awesome product');
+    });
+
+    it('should deny creating a product for not-owned facility', async function() {
+      await prisma.product.deleteMany();
+
+      const resBody = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'My first awesome product', facilityId: facility2.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.FORBIDDEN)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Forbidden',
+        'message': `userId=${user1.id} is not an owner of facilityId=${facility2.id}`,
+        'statusCode': 403
+      });
+    });
+
+    it('should deny creating a product for non-existing facility', async function() {
+      await prisma.product.deleteMany();
+
+      const resBody = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'My first awesome product', facilityId: 9999 })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.BAD_REQUEST)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Bad Request',
+        'message': 'non-existing facilityId=9999',
+        'statusCode': 400
+      });
+    });
+  });
+
+  describe('GET /products', function() {
+    it('should require a logged in user', async function() {
+      await request(httpServer)
+        .get('/products')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should require a user to have admin role', async function() {
+      await request(httpServer)
+        .get('/products')
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.FORBIDDEN);
+
+      await request(httpServer)
+        .get('/products')
+        .set(getAuthBearerHeader(adminAccessToken))
+        .expect(HttpStatus.OK);
+    });
+
+    it('should respond with products list', async function() {
+      await prisma.product.deleteMany();
+
+      await request(httpServer)
+        .post('/products')
+        .send({ name: 'My awesome product 1', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED);
+
+      await request(httpServer)
+        .post('/products')
+        .send({ name: 'My awesome product 2', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED);
+
+      const products = (await request(httpServer)
+        .get('/products')
+        .set(getAuthBearerHeader(adminAccessToken))
+        .expect(HttpStatus.OK)).body;
+
+      expect(products.length).toEqual(2);
+      expect(products[0].name).toEqual('My awesome product 1');
+      expect(products[1].name).toEqual('My awesome product 2');
+    });
+  });
+
+  describe('GET /products/:id', function() {
+    it('should require a logged in user', async function() {
+      await request(httpServer)
+        .get('/products/1')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should respond with a product details', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'My second awesome product', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED)).body;
+
+      const responseBody = (await request(httpServer)
+        .get(`/products/${product.id}`)
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.OK)).body;
+
+      expect(responseBody).toEqual(product);
+    });
+  });
+
+  describe('PUT /products/:id', function() {
+    it('should require a logged in user', async function() {
+      await request(httpServer)
+        .put('/products/1')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should update a product', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'My product to be updated', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED)).body;
+
+      (await request(httpServer)
+        .put(`/products/${product.id}`)
+        .send({ name: 'My product name updated', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.OK)).body;
+
+      const productUpdated = await prisma.product.findUnique({ where: { id: product.id } });
+
+      expect(productUpdated.name).toEqual('My product name updated');
+    });
+
+    it('should deny updating a product of not-owned facility', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'Not mine product to be updated', facilityId: facility2.id })
+        .set(getAuthBearerHeader(accessToken2))
+        .expect(HttpStatus.CREATED)).body;
+
+      const resBody = (await request(httpServer)
+        .put(`/products/${product.id}`)
+        .send({ name: 'My product name updated', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.FORBIDDEN)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Forbidden',
+        'message': `userId=${user1.id} is not an owner of facilityId=${facility2.id}`,
+        'statusCode': 403
+      });
+    });
+
+    it('should deny assigning a product to not-owned facility', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'Not mine product to be updated', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED)).body;
+
+      const resBody = (await request(httpServer)
+        .put(`/products/${product.id}`)
+        .send({ name: 'My product name updated', facilityId: facility2.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.FORBIDDEN)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Forbidden',
+        'message': `userId=${user1.id} is not an owner of facilityId=${facility2.id}`,
+        'statusCode': 403
+      });
+    });
+
+    it('should deny assigning a product to not-existing facility', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'Not mine product to be updated', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED)).body;
+
+      const resBody = (await request(httpServer)
+        .put(`/products/${product.id}`)
+        .send({ name: 'My product name updated', facilityId: 9999 })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.BAD_REQUEST)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Bad Request',
+        'message': 'non-existing facilityId=9999',
+        'statusCode': 400
+      });
+    });
+  });
+
+  describe('DELETE /products/:id', function() {
+    it('should require a logged in user', async function() {
+      await request(httpServer)
+        .delete('/products/1')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should remove a product', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'My product to be removed', facilityId: facility1.id })
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.CREATED)).body;
+
+      await request(httpServer)
+        .delete(`/products/${product.id}`)
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.OK);
+
+      expect((await prisma.product.findMany()).length).toEqual(0);
+    });
+
+    it('should deny removing a product of not-owned facility', async function() {
+      await prisma.product.deleteMany();
+
+      const product = (await request(httpServer)
+        .post('/products')
+        .send({ name: 'Not mine product to be updated', facilityId: facility2.id })
+        .set(getAuthBearerHeader(accessToken2))
+        .expect(HttpStatus.CREATED)).body;
+
+      const resBody = (await request(httpServer)
+        .delete(`/products/${product.id}`)
+        .set(getAuthBearerHeader(accessToken1))
+        .expect(HttpStatus.FORBIDDEN)).body;
+
+      expect(resBody).toEqual({
+        'error': 'Forbidden',
+        'message': `userId=${user1.id} is not an owner of facilityId=${facility2.id}`,
+        'statusCode': 403
+      });
+    });
+  });
+});

--- a/apps/zero-api/src/products/products.controller.ts
+++ b/apps/zero-api/src/products/products.controller.ts
@@ -1,0 +1,134 @@
+import {
+  BadRequestException,
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Logger,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseFilters,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe
+} from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { NoDataInterceptor } from '../interceptors/NoDataInterceptor';
+import { PrismaClientExceptionFilter } from '../exception-filters/PrismaClientExceptionFilter';
+import { ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ProductDto } from './dto/product.dto';
+import { User } from '../users/decorators/user.decorator';
+import { UserDto } from '../users/dto/user.dto';
+import { RequiredRoles } from '../auth/decorators/required-roles.decorator';
+import { UserRole } from '@prisma/client';
+import { FacilitiesService } from '../facilities/facilities.service';
+
+@Controller('products')
+@UsePipes(ValidationPipe)
+@UseInterceptors(ClassSerializerInterceptor, NoDataInterceptor)
+@UseFilters(PrismaClientExceptionFilter)
+@ApiTags('products')
+@ApiBearerAuth('access-token')
+export class ProductsController {
+  private readonly logger = new Logger(ProductsController.name, { timestamp: true });
+
+  constructor(
+    private readonly productsService: ProductsService,
+    private readonly facilitiesService: FacilitiesService
+  ) {}
+
+  @Post()
+  @ApiCreatedResponse({ type: ProductDto })
+  async create(
+    @User() user: UserDto,
+    @Body() createProductDto: CreateProductDto
+  ): Promise<ProductDto> {
+    const facility = await this.facilitiesService.findOne(createProductDto.facilityId);
+
+    if (!facility) {
+      throw new BadRequestException((`non-existing facilityId=${createProductDto.facilityId}`));
+    }
+
+    if (user.id !== facility.ownerId) {
+      throw new ForbiddenException(`userId=${user.id} is not an owner of facilityId=${facility.id}`);
+    }
+
+    return this.productsService.create(createProductDto);
+  }
+
+  @Get()
+  @RequiredRoles(UserRole.admin)
+  @ApiOkResponse({ type: [ProductDto] })
+  findAll(): Promise<ProductDto[]> {
+    return this.productsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOkResponse({ type: ProductDto })
+  findOne(@Param('id', new ParseIntPipe()) id: number): Promise<ProductDto> {
+    return this.productsService.findOne(+id);
+  }
+
+  @Put(':id')
+  @ApiOkResponse({ type: ProductDto })
+  async update(
+    @User() user: UserDto,
+    @Param('id', new ParseIntPipe()) id: number,
+    @Body() updateProductDto: UpdateProductDto
+  ): Promise<ProductDto> {
+    const product = await this.productsService.findOne(id);
+    if (!product) {
+      this.logger.warn(`userId=${user.id} tried to update non-existing productId=${id}`);
+      throw new NotFoundException();
+    }
+
+    const currentFacility = await this.facilitiesService.findOne(product.facilityId);
+    if (currentFacility.ownerId !== user.id) {
+      this.logger.warn(`userId=${user.id} tried to update productId=${id} of not-owned facilityId=${currentFacility.id}`);
+      throw new ForbiddenException(`userId=${user.id} is not an owner of facilityId=${currentFacility.id}`);
+    }
+
+    if (updateProductDto.facilityId && product.facilityId !== updateProductDto.facilityId) {
+      const newFacility = await this.facilitiesService.findOne(updateProductDto.facilityId);
+      if (!newFacility) {
+        this.logger.warn(`userId=${user.id} tried to update productId=${id} to non-existing facilityId=${updateProductDto.facilityId}`);
+        throw new BadRequestException((`non-existing facilityId=${updateProductDto.facilityId}`));
+      }
+
+      if (user.id !== newFacility.ownerId) {
+        this.logger.warn(`userId=${user.id} tried to update productId=${id} to not-owned facilityId=${newFacility.id}`);
+        throw new ForbiddenException(`userId=${user.id} is not an owner of facilityId=${newFacility.id}`);
+      }
+    }
+
+    return this.productsService.update(+id, updateProductDto);
+  }
+
+  @Delete(':id')
+  @ApiOkResponse()
+  async remove(
+    @User() user: UserDto,
+    @Param('id', new ParseIntPipe()) id: number
+  ) {
+    const product = await this.productsService.findOne(id);
+    if (!product) {
+      this.logger.warn(`userId=${user.id} tried to delete non-existing productId=${id}`);
+      throw new NotFoundException();
+    }
+
+    const facility = await this.facilitiesService.findOne(product.facilityId);
+    if (facility.ownerId !== user.id) {
+      this.logger.warn(`userId=${user.id} tried to delete productId=${id} of not-owned facilityId=${facility.id}`);
+      throw new ForbiddenException(`userId=${user.id} is not an owner of facilityId=${facility.id}`);
+    }
+
+    return this.productsService.remove(+id);
+  }
+}

--- a/apps/zero-api/src/products/products.module.ts
+++ b/apps/zero-api/src/products/products.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProductsService } from './products.service';
+import { ProductsController } from './products.controller';
+import { FacilitiesService } from '../facilities/facilities.service';
+
+@Module({
+  controllers: [ProductsController],
+  providers: [FacilitiesService, ProductsService]
+})
+export class ProductsModule {}

--- a/apps/zero-api/src/products/products.service.spec.ts
+++ b/apps/zero-api/src/products/products.service.spec.ts
@@ -1,0 +1,159 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsService } from './products.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AppModule } from '../app/app.module';
+import { UserDto } from '../users/dto/user.dto';
+import { createAndActivateUser } from '../../test/helpers';
+import { UsersService } from '../users/users.service';
+import { User, UserRole } from '@prisma/client';
+import { FacilitiesService } from '../facilities/facilities.service';
+import { FacilityDto } from '../facilities/dto/facility.dto';
+
+describe('ProductsService', () => {
+  let module: TestingModule;
+  let prisma: PrismaService;
+  let service: ProductsService;
+  let usersService: UsersService;
+  let facilitiesService: FacilitiesService;
+  let user1: UserDto;
+  let user2: UserDto;
+  let facility1: FacilityDto;
+  let facility2: FacilityDto;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    service = module.get<ProductsService>(ProductsService);
+    prisma = module.get<PrismaService>(PrismaService);
+    usersService = module.get<UsersService>(UsersService);
+    facilitiesService = module.get<FacilitiesService>(FacilitiesService);
+
+    await prisma.clearDatabase();
+
+    user1 = await createAndActivateUser(usersService, prisma, {
+      firstName: 'test first name 1',
+      lastName: 'test last name 1',
+      email: 'test-email1@foo.bar',
+      roles: [UserRole.buyer],
+      password: 'test password 1'
+    } as User);
+
+    user2 = await createAndActivateUser(usersService, prisma, {
+      firstName: 'test first name 2',
+      lastName: 'test last name 2',
+      email: 'test-email2@foo.bar',
+      roles: [UserRole.seller],
+      password: 'test password 2'
+    } as User);
+
+    facility1 = await facilitiesService.create({ name: 'facility 1' }, user1.id);
+    facility2 = await facilitiesService.create({ name: 'facility 2' }, user2.id);
+  });
+
+  afterAll(async function() {
+    await module.close();
+  });
+
+  beforeEach(async function() {
+    await prisma.product.deleteMany();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create()', function() {
+    it('should create a new db record', async function() {
+      expect((await prisma.product.findMany()).length).toEqual(0);
+      const result = await service.create({ name: 'New product name', facilityId: facility1.id });
+
+      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.facilityId).toEqual(facility1.id);
+
+      const dbRecords = await prisma.product.findMany();
+
+      expect(dbRecords.length).toEqual(1);
+      expect(dbRecords[0].name).toEqual('New product name');
+
+      expect(result).toEqual(dbRecords[0]);
+    });
+  });
+
+  describe('findAll()', function() {
+    let r1, r2, r3;
+
+    beforeEach(async function() {
+      expect((await prisma.product.findMany()).length).toEqual(0);
+      r1 = await service.create({ name: 'New product name 1', facilityId: facility1.id });
+      r2 = await service.create({ name: 'New product name 2', facilityId: facility1.id });
+      r3 = await service.create({ name: 'New product name 3', facilityId: facility2.id });
+    });
+
+    it('should return all db records', async function() {
+      const result = await service.findAll();
+
+      expect(result.length).toEqual(3);
+      expect(result[0].name).toEqual('New product name 1');
+      expect(result[1].name).toEqual('New product name 2');
+      expect(result[2].name).toEqual('New product name 3');
+
+      expect(r1).toEqual(result[0]);
+      expect(r2).toEqual(result[1]);
+      expect(r3).toEqual(result[2]);
+    });
+  });
+
+  describe('findOne()', function() {
+    it('should return a record', async function() {
+      expect((await prisma.product.findMany()).length).toEqual(0);
+      const r1 = await service.create({ name: 'New product name 1', facilityId: facility1.id });
+      await service.create({ name: 'New product name 2', facilityId: facility1.id });
+      await service.create({ name: 'New product name 3', facilityId: facility2.id });
+
+      const result = await service.findOne(r1.id);
+
+      expect(r1).toEqual(result);
+    });
+  });
+
+  describe('update()', function() {
+    let r1, r2, r3;
+
+    beforeEach(async function() {
+      expect((await prisma.product.findMany()).length).toEqual(0);
+      r1 = await service.create({ name: 'New product name 1', facilityId: facility1.id });
+      r2 = await service.create({ name: 'New product name 2', facilityId: facility1.id });
+      r3 = await service.create({ name: 'New product name 3', facilityId: facility2.id });
+    });
+
+    it('should update a given record', async function() {
+      await service.update(r1.id, { name: 'Updated product name 1' });
+
+      expect((await prisma.product.findUnique({ where: { id: r1.id } })).name).toEqual('Updated product name 1');
+      expect((await prisma.product.findUnique({ where: { id: r2.id } }))).toEqual(r2);
+      expect((await prisma.product.findUnique({ where: { id: r3.id } }))).toEqual(r3);
+    });
+  });
+
+  describe('remove()', function() {
+    let r1, r2, r3;
+
+    beforeEach(async function() {
+      expect((await prisma.product.findMany()).length).toEqual(0);
+      r1 = await service.create({ name: 'New product name 1', facilityId: facility1.id });
+      r2 = await service.create({ name: 'New product name 2', facilityId: facility1.id });
+      r3 = await service.create({ name: 'New product name 3', facilityId: facility2.id });
+    });
+
+    it('should remove a given record', async function() {
+      await service.remove(r1.id);
+
+      expect((await prisma.product.findUnique({ where: { id: r1.id } }))).toBeNull();
+      expect((await prisma.product.findUnique({ where: { id: r2.id } }))).not.toBeNull();
+      expect((await prisma.product.findUnique({ where: { id: r3.id } }))).not.toBeNull();
+    });
+  });
+});

--- a/apps/zero-api/src/products/products.service.ts
+++ b/apps/zero-api/src/products/products.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { ProductDto } from './dto/product.dto';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ProductsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(createProductDto: CreateProductDto): Promise<ProductDto> {
+    return new ProductDto(await this.prisma.product.create({ data: createProductDto }));
+  }
+
+  async findAll(): Promise<ProductDto[]> {
+    return (await this.prisma.product.findMany()).map((row) => new ProductDto(row));
+  }
+
+  async findOne(id: number): Promise<ProductDto> {
+    const dbRecord = await this.prisma.product.findUnique({ where: { id } });
+    if (!dbRecord) return null;
+    return new ProductDto(dbRecord);
+  }
+
+  async update(id: number, updateProductDto: UpdateProductDto): Promise<ProductDto> {
+    return new ProductDto(await this.prisma.product.update({ where: { id }, data: updateProductDto }));
+  }
+
+  async remove(id: number): Promise<ProductDto> {
+    return await this.prisma.product.delete({ where: { id } });
+  }
+}

--- a/apps/zero-api/swagger.json
+++ b/apps/zero-api/swagger.json
@@ -1126,6 +1126,173 @@
           }
         ]
       }
+    },
+    "/api/products": {
+      "post": {
+        "operationId": "ProductsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProductDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "products"
+        ],
+        "security": [
+          {
+            "access-token": []
+          }
+        ]
+      },
+      "get": {
+        "operationId": "ProductsController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProductDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "products"
+        ],
+        "security": [
+          {
+            "access-token": []
+          }
+        ]
+      }
+    },
+    "/api/products/{id}": {
+      "get": {
+        "operationId": "ProductsController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "products"
+        ],
+        "security": [
+          {
+            "access-token": []
+          }
+        ]
+      },
+      "put": {
+        "operationId": "ProductsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "products"
+        ],
+        "security": [
+          {
+            "access-token": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "ProductsController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "products"
+        ],
+        "security": [
+          {
+            "access-token": []
+          }
+        ]
+      }
     }
   },
   "info": {
@@ -1553,6 +1720,58 @@
           "name": {
             "type": "string",
             "example": "My facility"
+          }
+        }
+      },
+      "CreateProductDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "My product"
+          },
+          "facilityId": {
+            "type": "number",
+            "example": 1
+          }
+        },
+        "required": [
+          "name",
+          "facilityId"
+        ]
+      },
+      "ProductDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "facilityId": {
+            "type": "number",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "My product"
+          }
+        },
+        "required": [
+          "id",
+          "facilityId",
+          "name"
+        ]
+      },
+      "UpdateProductDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "My product"
+          },
+          "facilityId": {
+            "type": "number",
+            "example": 1
           }
         }
       }


### PR DESCRIPTION
This PR adds a "Products" feature base to be extended in the next iterations to meet UI requirements. 
The following endpoints are implemented:
- POST /api/products
- PUT /api/products
- GET /api/products (admin only)
- GET /api/products/:id
- DELETE /api/products/:id
