### PR TITLE
fix: 500 error when malformed request

### DIFF
--- a/apps/zero-api/src/files/files.controller.ts
+++ b/apps/zero-api/src/files/files.controller.ts
@@ -82,6 +82,11 @@ export class FilesController {
     @Body() body: UploadFileDto,
     @UploadedFile() file: Express.Multer.File
   ): Promise<UploadFileResponseDto> {
+    if (!file) {
+      this.logger.warn(`${user.email} made a request with no file`);
+      throw new BadRequestException('request with no file');
+    }
+
     this.logger.debug(`${user.email} is uploading a file: ${file.originalname}`);
     this.logger.debug(`form fields: ${JSON.stringify(body)}`);
 


### PR DESCRIPTION
Fixed an issue when 500 error response is returned instead of 400 bad request when POST /api/files endpoint requested with no file