### PR TITLE
fix: broken CI s3 credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
           SMTP_URL: "smtp://localhost:1025"
           AWS_BUCKET: "ew-zero-uploaded-files-dev"
           AWS_REGION: "us-west-2"
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID_SANDBOX}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY_SANDBOX}}
 
 # Disabled until UI tests are fixed
 #      - name: Run UI tests


### PR DESCRIPTION
Changed secrets used as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY