### PR TITLE
fix: tests timing out when S3 files upload is slow

### DIFF
--- a/apps/zero-api/src/files/files.service.spec.ts
+++ b/apps/zero-api/src/files/files.service.spec.ts
@@ -4,7 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { tmpdir } from 'os';
 import { resolve } from 'path';
 import { Express } from 'express';
-import { createAndActivateUser, createUploadedFile, fileExists, removeFolderContent } from '../../test/helpers';
+import { createAndActivateUser, createDocumentDbRecord, createUploadedFile, fileExists } from '../../test/helpers';
 import { UsersService } from '../users/users.service';
 import { FileType, User, UserRole } from '@prisma/client';
 import { AppModule } from '../app/app.module';
@@ -157,17 +157,10 @@ describe('FilesService', () => {
     });
 
     beforeEach(async function() {
-      const uploadedFile1 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await service.addFile(uploadedFile1.path, uploadedFile1.originalname, uploadedFile1.mimetype, anotherUser.id);
-
-      const uploadedFile2 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await service.addFile(uploadedFile2.path, uploadedFile2.originalname, uploadedFile2.mimetype, user.id);
-
-      const uploadedFile3 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await service.addFile(uploadedFile3.path, uploadedFile3.originalname, uploadedFile3.mimetype, user.id);
-
-      const uploadedFile4 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await service.addFile(uploadedFile4.path, uploadedFile4.originalname, uploadedFile4.mimetype, user.id);
+      await createDocumentDbRecord(prismaService, anotherUser.id);
+      await createDocumentDbRecord(prismaService, user.id);
+      await createDocumentDbRecord(prismaService, user.id);
+      await createDocumentDbRecord(prismaService, user.id);
     });
 
     afterEach(async function() {

--- a/apps/zero-api/src/files/files.service.spec.ts
+++ b/apps/zero-api/src/files/files.service.spec.ts
@@ -60,7 +60,7 @@ describe('FilesService', () => {
     beforeEach(async function() {
       expect(await fileExists(testFile)).toEqual(true);
       uploadedFile = await createUploadedFile(testFile, temporaryFolder);
-    });
+    }, 20000);
 
     it('should create database record', async function() {
       const res = await service.addFile(uploadedFile.path, uploadedFile.originalname, uploadedFile.mimetype, user.id);
@@ -69,7 +69,7 @@ describe('FilesService', () => {
       expect(databaseRecord).toBeDefined();
       expect(databaseRecord.filename).toEqual(uploadedFile.originalname);
       expect(databaseRecord.ownerId).toEqual(user.id);
-    });
+    }, 20000);
 
     it('should store a file in the S3 bucket', async function() {
       const fileMetadata = await service.addFile(uploadedFile.path, uploadedFile.originalname, uploadedFile.mimetype, user.id);
@@ -81,7 +81,7 @@ describe('FilesService', () => {
       expect(res.status).toEqual(200);
       expect(res.headers['content-disposition']).toBeDefined();
       expect(res.headers['content-disposition']).toContain(`filename=${fileMetadata.filename}`);
-    });
+    }, 20000);
   });
 
   describe('getFileMetadata()', function() {

--- a/apps/zero-api/src/users/users-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-files.controller.spec.ts
@@ -7,17 +7,9 @@ import { UsersService } from './users.service';
 import { UserDto } from './dto/user.dto';
 import { User, UserRole } from '@prisma/client';
 import * as request from 'supertest';
-import {
-  createAndActivateUser,
-  createUploadedFile,
-  getAuthBearerHeader,
-  logInUser,
-  removeFolderContent
-} from '../../test/helpers';
+import { createAndActivateUser, createDocumentDbRecord, getAuthBearerHeader, logInUser } from '../../test/helpers';
 import { UsersFilesController } from './users-files.controller';
 import { FilesService } from '../files/files.service';
-import { resolve } from 'path';
-import { tmpdir } from 'os';
 import { FileMetadataDto } from '../files/dto/file-metadata.dto';
 
 describe('UsersFilesController', function() {
@@ -26,8 +18,6 @@ describe('UsersFilesController', function() {
   let controller: UsersDraftsController;
   let prisma: PrismaService;
   let usersService: UsersService;
-  let filesService: FilesService;
-  const temporaryFolder = tmpdir();
   let user1: UserDto, user2: UserDto;
   let accessToken1: string;
 
@@ -48,7 +38,6 @@ describe('UsersFilesController', function() {
     controller = module.get<UsersDraftsController>(UsersDraftsController);
     prisma = module.get<PrismaService>(PrismaService);
     usersService = module.get<UsersService>(UsersService);
-    filesService = module.get<FilesService>(FilesService);
 
     await prisma.clearDatabase();
 
@@ -83,18 +72,11 @@ describe('UsersFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      const uploadedFile1 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile1.path, uploadedFile1.originalname, uploadedFile1.mimetype, user2.id);
-
-      const uploadedFile2 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile2.path, uploadedFile2.originalname, uploadedFile2.mimetype, user1.id);
-
-      const uploadedFile3 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile3.path, uploadedFile3.originalname, uploadedFile3.mimetype, user1.id);
-
-      const uploadedFile4 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile4.path, uploadedFile4.originalname, uploadedFile4.mimetype, user1.id);
-    }, 20000);
+      await createDocumentDbRecord(prisma, user2.id);
+      await createDocumentDbRecord(prisma, user1.id);
+      await createDocumentDbRecord(prisma, user1.id);
+      await createDocumentDbRecord(prisma, user1.id);
+    });
 
     it('should deny access when not authenticated', async function() {
       const { body } = (await request(httpServer)

--- a/apps/zero-api/src/users/users-own-files.controller.spec.ts
+++ b/apps/zero-api/src/users/users-own-files.controller.spec.ts
@@ -6,15 +6,8 @@ import { UsersService } from './users.service';
 import { UserDto } from './dto/user.dto';
 import { User, UserRole } from '@prisma/client';
 import * as request from 'supertest';
-import {
-  createAndActivateUser,
-  createUploadedFile,
-  getAuthBearerHeader,
-  logInUser,
-  removeFolderContent
-} from '../../test/helpers';
+import { createAndActivateUser, createDocumentDbRecord, getAuthBearerHeader, logInUser } from '../../test/helpers';
 import { FilesService } from '../files/files.service';
-import { resolve } from 'path';
 import { tmpdir } from 'os';
 import { FileMetadataDto } from '../files/dto/file-metadata.dto';
 import { UsersOwnFilesController } from './users-own-files.controller';
@@ -80,18 +73,11 @@ describe('UsersOwnFilesController', function() {
 
   describe('GET users/:userId/files', function() {
     beforeAll(async function() {
-      const uploadedFile1 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile1.path, uploadedFile1.originalname, uploadedFile1.mimetype, user2.id);
-
-      const uploadedFile2 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile2.path, uploadedFile2.originalname, uploadedFile2.mimetype, user1.id);
-
-      const uploadedFile3 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile3.path, uploadedFile3.originalname, uploadedFile3.mimetype, user1.id);
-
-      const uploadedFile4 = await createUploadedFile(resolve(__dirname, '../../test/test-files/test-file.pdf'), temporaryFolder);
-      await filesService.addFile(uploadedFile4.path, uploadedFile4.originalname, uploadedFile4.mimetype, user1.id);
-    }, 20000);
+      await createDocumentDbRecord(prisma, user2.id);
+      await createDocumentDbRecord(prisma, user1.id);
+      await createDocumentDbRecord(prisma, user1.id);
+      await createDocumentDbRecord(prisma, user1.id);
+    });
 
     it('should deny access when not authenticated', async function() {
       const { body } = (await request(httpServer)


### PR DESCRIPTION
Test are optimized to not upload actual files to S3 bucket when just checking a logic dependant on the database records.